### PR TITLE
Update security meta layer for new linux and uboot branches

### DIFF
--- a/meta-adi-adsp-sc5xx-security/recipes-bsp/adsp-boot/adsp-boot_git.bbappend
+++ b/meta-adi-adsp-sc5xx-security/recipes-bsp/adsp-boot/adsp-boot_git.bbappend
@@ -13,4 +13,4 @@ STAGE_2_SRC:append:optee-shim = " optee-shim.elf"
 
 # If we'll be signing the output later, call it unsigned for the signing recipe
 # to be able to find it
-STAGE_2_TARGET_NAME:adsp-sc5xx-signedboot = "stage2-boot-unsigned.ldr"
+STAGE_2_TARGET_NAME:adsp-sc5xx-signedboot = "u-boot-unsigned.ldr"

--- a/meta-adi-adsp-sc5xx-security/recipes-bsp/adsp-boot/adsp-signed-boot.bb
+++ b/meta-adi-adsp-sc5xx-security/recipes-bsp/adsp-boot/adsp-signed-boot.bb
@@ -18,7 +18,7 @@ SIGNTOOL_PROC:adsp-sc598-som-ezkit = "ADSP-SC598"
 
 SIGNTOOL_ALGO = "ecdsa256"
 
-UNSIGNED_SRC = "stage1-boot-unsigned.ldr stage2-boot-unsigned.ldr"
+UNSIGNED_SRC = "u-boot-spl-unsigned.ldr u-boot-unsigned.ldr"
 
 do_configure() {
 	if [ -z "${ADI_SIGNTOOL_KEY}" ]; then
@@ -44,12 +44,12 @@ do_compile() {
 
 	${ADI_SIGNTOOL_PATH} -proc ${SIGNTOOL_PROC} sign -type ${ADI_SIGNATURE_TYPE} -algo ${SIGNTOOL_ALGO} \
 		-attribute 0x80000002=${LDR_BCODE} \
-		-infile stage1-boot-unsigned.ldr -outfile stage1-boot.ldr \
+		-infile u-boot-spl-unsigned.ldr -outfile u-boot-spl.ldr \
 		-prikey ${ADI_SIGNTOOL_KEY}
 
 	${ADI_SIGNTOOL_PATH} -proc ${SIGNTOOL_PROC} sign -type ${ADI_SIGNATURE_TYPE} -algo ${SIGNTOOL_ALGO} \
 		-attribute 0x80000002=${LDR_BCODE} \
-		-infile stage2-boot-unsigned.ldr -outfile stage2-boot.ldr \
+		-infile u-boot-unsigned.ldr -outfile u-boot.ldr \
 		-prikey ${ADI_SIGNTOOL_KEY}
 }
 
@@ -60,8 +60,8 @@ do_install() {
 }
 
 do_deploy() {
-	install -m 0755 ${WORKDIR}/stage1-boot.ldr ${DEPLOYDIR}/
-	install -m 0755 ${WORKDIR}/stage2-boot.ldr ${DEPLOYDIR}/
+	install -m 0755 ${WORKDIR}/u-boot-spl.ldr ${DEPLOYDIR}/
+	install -m 0755 ${WORKDIR}/u-boot.ldr ${DEPLOYDIR}/
 }
 
 addtask do_deploy after do_compile before do_build

--- a/meta-adi-adsp-sc5xx-security/recipes-bsp/u-boot/u-boot-adi_2025.10.bbappend
+++ b/meta-adi-adsp-sc5xx-security/recipes-bsp/u-boot/u-boot-adi_2025.10.bbappend
@@ -1,7 +1,7 @@
 
 DEPENDS:append:adsp-sc5xx-signedboot = " u-boot-mkimage-native dtc-native"
 
-STAGE_1_TARGET_NAME:adsp-sc5xx-signedboot = "stage1-boot-unsigned.ldr"
+STAGE_1_TARGET_NAME:adsp-sc5xx-signedboot = "u-boot-spl-unsigned.ldr"
 
 # Actual contents of this don't matter, we just need to sign this fit image in order to get uboot
 # to update the dtb with the key that was used for signing, which will be used to sign the kernel
@@ -63,15 +63,16 @@ do_configure:prepend:adsp-sc5xx-signedboot() {
 do_compile:prepend:adsp-sc5xx-signedboot(){
 	sits_emit
 
-	DTS_NAME=$(cat ${S}/configs/${UBOOT_MACHINE} | grep DEVICE_TREE | sed -e 's/.*="//g' -e 's/"//g')
+	DTS_NAME=$(echo "${MACHINE}" | sed 's/^adsp-//')
 
 	INCLUDE=${S}/arch/arm/dts/
 	INCLUDE2=${S}/include
 	INCLUDE3=${S}/arch/arm/include/asm
+	INCLUDE4=${S}/dts/upstream/include
 	SRC=${S}/arch/arm/dts/${DTS_NAME}.dts
 	TMP=${WORKDIR}/${DTS_NAME}.dts.tmp
 
-	cpp -nostdinc -I${INCLUDE} -I${INCLUDE2} -I${INCLUDE3} -undef -x assembler-with-cpp ${SRC} > ${TMP}
+	cpp -nostdinc -I${INCLUDE} -I${INCLUDE2} -I${INCLUDE3} -I${INCLUDE4} -undef -x assembler-with-cpp ${SRC} > ${TMP}
 
 	dtc ${UBOOT_MKIMAGE_DTCOPTS} \
 	-o ${WORKDIR}/${DTS_NAME}.dtb ${TMP}


### PR DESCRIPTION
Updating the security meta layer for the new U-boot and Linux branches. Only small changes in the security repo, just some file name changes and adjustment of a recipe to avoid using a deprecated defconfig option